### PR TITLE
Add Flask Tailwind application skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# codex
-codex
+# Flask Tailwind Application
+
+This repository provides a minimal fullstack application template using **Flask**, **Tailwind CSS**, **SQLite** and **SQLAlchemy** as the ORM.
+
+## Project structure
+```
+app/
+  __init__.py       - Application factory and database setup
+  models.py         - SQLAlchemy models
+  routes.py         - Application routes
+  templates/
+    base.html       - Base template with Tailwind
+    index.html      - Home page example
+  static/           - Static assets
+config.py           - Configuration (SQLite database path)
+manage.py           - Run the application
+requirements.txt    - Python dependencies
+```
+
+## Setup
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python manage.py
+   ```
+3. Open `http://localhost:5000` in your browser.
+
+Tailwind CSS is included via CDN in `templates/base.html`. Adjust as needed for production setups.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,16 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+# Initialize the database object (SQLAlchemy ORM)
+db = SQLAlchemy()
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object('config.Config')
+
+    db.init_app(app)
+
+    with app.app_context():
+        from . import routes  # Import routes
+        db.create_all()  # Create tables if they don't exist
+        return app

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,8 @@
+from . import db
+
+class Item(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), nullable=False)
+
+    def __repr__(self):
+        return f'<Item {self.name}>'

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,9 @@
+from flask import render_template
+from . import db
+from .models import Item
+from flask import current_app as app
+
+@app.route('/')
+def index():
+    items = Item.query.all()
+    return render_template('index.html', items=items)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Flask Tailwind App{% endblock %}</title>
+    <!-- Tailwind via CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100">
+    <div class="container mx-auto p-4">
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+
+{% block title %}Home{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Items</h1>
+<ul>
+    {% for item in items %}
+    <li class="border p-2 mb-2">{{ item.name }}</li>
+    {% else %}
+    <li>No items yet.</li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+import os
+
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'dev')
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(BASE_DIR, 'app.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy


### PR DESCRIPTION
## Summary
- set up `app` package with Flask application factory
- add SQLAlchemy model, routes, and templates with Tailwind CSS via CDN
- include config for SQLite database
- provide a simple manage script and Python dependencies
- update README with setup instructions

## Testing
- `python -m py_compile app/*.py manage.py config.py`

------
https://chatgpt.com/codex/tasks/task_b_68554cc03b34832ebd20da85a5b43da7